### PR TITLE
adding in new option to remove all recommended posts from a users dash

### DIFF
--- a/data/options.html
+++ b/data/options.html
@@ -210,6 +210,9 @@
           <div id="hide_premium_div">
             <input type="checkbox" id="hide_premium_cb" name="hide_premium_cb" /> <label for="hide_premium_cb">Hide sponsored radar entries.</label>
           </div>
+          <div id="hide_recommended_div">
+            <input type="checkbox" id="hide_recommended_cb" name="hide_recommended_cb" /> <label for="hide_recommended_cb">Hide recommended posts.</label>
+          </div>
         </div>
         <div id="saveloadDiv">
           <h2>Save / Load</h2><br />

--- a/data/options.js
+++ b/data/options.js
@@ -35,7 +35,8 @@ settingsInputs = { //match up our settings object with our dom.
 		hide_pinned: 'hide_pinned_cb',
 		auto_unpin: 'auto_unpin_cb',
 		show_tags: 'show_tags_cb',
-		hide_premium: 'hide_premium_cb'
+		hide_premium: 'hide_premium_cb',
+		hide_recommended: 'hide_recommended_cb'
 	},
 	lists:  {
 		listBlack: 'listBlack',

--- a/data/script.js
+++ b/data/script.js
@@ -441,6 +441,10 @@ function checkPost(post) {
 		unpin(post);
 	}
 
+	if (settings.hide_recommended && post.className.indexOf('is_recommended') >= 0) {
+			post.parentNode.removeChild(post);
+	}
+
 	olPosts = document.getElementById('posts');
 
 	if (post.tagName === 'DIV') {


### PR DESCRIPTION
Friends noticed that Tumblr savior doesn't have an option to block recommended posts on their dashboard. This patch adds in that ability. This is my first commit to an open source project so am I sorry If I did something incorrectly 
