### PR TITLE
Fix context menu disabling on Safari.

### DIFF
--- a/src/data/main.js
+++ b/src/data/main.js
@@ -164,6 +164,17 @@ function safariContextMenuHandler(event) {
 	}
 }
 
+function safariValidateHandler(event) {
+	var settings;
+
+	if (event.command === 'addToBlackList') {
+		settings = parseSettings();
+		if (!settings.context_menu || event.userInfo === null) {
+			event.target.disabled = true
+		}
+	}
+}
+
 switch (browser) {
 case 'Chrome':
 	console.log('Setting up the',browser,'backend.');
@@ -190,6 +201,7 @@ case 'Safari':
 	safari.application.addEventListener('message', safariMessageHandler, false);
 	safari.application.addEventListener('command', safariCommandHandler, false);
 	safari.application.addEventListener('contextmenu', safariContextMenuHandler, false);
+	safari.application.addEventListener('validate', safariValidateHandler, false);
 	break;
 case 'Firefox':
 	console.log('Setting up the',browser,'backend.');


### PR DESCRIPTION
The context_menu setting was silently being ignored on Safari. Also, the context menu would incorrectly show up on non-Tumblr domains (regardless of the context_menu setting), and when no text was selected. This pull request fixes all of these issues.
