### PR TITLE
Use typographic double quotes in the Safari context menu

### DIFF
--- a/src/data/main.js
+++ b/src/data/main.js
@@ -160,7 +160,7 @@ function safariContextMenuHandler(event) {
 			wordBlack = wordBlack.replace(/^\s+|\s+$/g, '');
 			wordBlack = wordBlack + '...';
 		}
-		event.contextMenu.appendContextMenuItem('addToBlackList', 'Add \'' + wordBlack + '\' to Tumblr Savior black list');
+		event.contextMenu.appendContextMenuItem('addToBlackList', 'Add \u201c' + wordBlack + '\u201d to Tumblr Savior black list');
 	}
 }
 


### PR DESCRIPTION
This brings the typography in the Safari context menu in line with OS X / Safari standards—for example, the Look Up context menu:

![screenshot](http://i.imgur.com/fbDzNIs.png)
