### PR TITLE
v0.4.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 #Tumblr Savior Changelog
 
+##v0.4.23
+  * Added lists UI feature:
+    * When focused on non-empty input field, release enter to add new field and change focus to it
+    * When focused on empty input field, release backspace to remove current field.  Does not remove an input field if it is the only one.  If available, changes focus to previous field, else change focus to next field.
+  * Changed list remove button click-handler to named function (removeInputHandler), in order to be used with added feature.
+
 ##v0.4.22
  * Added options to ignore header, content, and/or tags of posts.
  * Added an option to hide yahoo advertisements (fixes #28)

--- a/src/Info.plist
+++ b/src/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.22</string>
+	<string>0.4.23</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>Chrome</key>

--- a/src/data/defaults.js
+++ b/src/data/defaults.js
@@ -1,5 +1,5 @@
 var defaultSettings = {
-	'version': '0.4.22',
+	'version': '0.4.23',
 	'listBlack': ['iphone', 'ipad'],
 	'listWhite': ['bjorn', 'octopus'],
 	'show_notice': true,

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -126,7 +126,6 @@ function parseSettings() {
 	return parsedSettings;
 }
 
-
 function removeInput(optionWhich) {
 	var optionInput = document.getElementById(optionWhich);
 	if (!optionInput) {
@@ -135,8 +134,45 @@ function removeInput(optionWhich) {
 	optionInput.parentNode.removeChild(optionInput);
 }
 
+function removeInputHandler(e) {
+	var removeThis = e.target;
+	while (removeThis.tagName !== 'DIV') {
+		removeThis = removeThis.parentNode;
+	}
+	if (removeThis.id.indexOf('_div') >= 0) {
+		removeInput(removeThis.id);
+	}
+	e.preventDefault();
+	e.stopPropagation();
+}
+
+function inputKeyUpHandler(e) {
+	var keycode = e.which;
+	if (8 !== keycode && 13 !== keycode) return;
+
+	var nextFocusId, divObject = e.target, inputLength = divObject.value.length;
+	while (divObject.tagName !== 'DIV') divObject = divObject.parentNode;
+
+	if (0 === inputLength && 8 === keycode) {
+		var i, siblings = [divObject.previousSibling, divObject.nextSibling];
+		for (i = 0; i < siblings.length; i++)
+			if (undefined !== siblings[i] && "DIV" === siblings[i].tagName) {
+				nextFocusId = siblings[i].getElementsByTagName('INPUT')[0].id;
+				removeInputHandler(e);
+				break;
+			}
+	}
+	else if (0 !== inputLength && 13 === keycode) {
+		var whichList = divObject.parentNode.id;
+		nextFocusId = 'option' + whichList + inputLast; 
+		addInput(whichList);
+	}
+
+	if (undefined !== nextFocusId) document.getElementById(nextFocusId).focus();
+}
+
 function addInput(whichList, itemValue) {
-	var listDiv, listAdd, optionInput, currentLength, removeThis, optionAdd, optionImage, optionLinebreak, optionDiv;
+	var listDiv, listAdd, optionInput, currentLength, optionAdd, optionImage, optionLinebreak, optionDiv;
 
 	if (itemValue === undefined) { //if we don't pass an itemValue, make it blank.
 		itemValue = '';
@@ -151,20 +187,16 @@ function addInput(whichList, itemValue) {
 	optionInput.value = itemValue;
 	optionInput.name = 'option' + whichList;
 	optionInput.id = 'option' + whichList + currentLength;
+	optionInput.addEventListener('focus', function(e) {
+		e.target.addEventListener('keyup', inputKeyUpHandler);
+	});
+	optionInput.addEventListener('blur', function(e) {
+		e.target.removeEventListener('keyup', inputKeyUpHandler);
+	});
 
 	optionAdd = document.createElement('a');
 	optionAdd.href = '#';
-	optionAdd.addEventListener('click', function (e) {
-		removeThis = e.target;
-		while (removeThis.tagName !== 'DIV') {
-			removeThis = removeThis.parentNode;
-		}
-		if (removeThis.id.indexOf('_div') >= 0) {
-			removeInput(removeThis.id);
-		}
-		e.preventDefault();
-		e.stopPropagation();
-	}, false);
+	optionAdd.addEventListener('click', removeInputHandler, false);
 
 	optionAdd.appendChild(document.createTextNode('\u00A0'));
 

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -147,28 +147,35 @@ function removeInputHandler(e) {
 }
 
 function inputKeyUpHandler(e) {
-	var keycode = e.which;
-	if (8 !== keycode && 13 !== keycode) return;
+	var wasEmptyObject, nextFocusId, keycode = e.which, target = e.target, inputLength = target.value.length, divObject = target.parentNode, wasEmptyObj = divObject.getElementsByTagName('PARAM')[0], wasEmpty = 'true' === wasEmptyObj.value ? true : false;
 
-	var nextFocusId, divObject = e.target, inputLength = divObject.value.length;
-	while (divObject.tagName !== 'DIV') divObject = divObject.parentNode;
-
-	if (0 === inputLength && 8 === keycode) {
-		var i, siblings = [divObject.previousSibling, divObject.nextSibling];
-		for (i = 0; i < siblings.length; i++)
-			if (undefined !== siblings[i] && "DIV" === siblings[i].tagName) {
-				nextFocusId = siblings[i].getElementsByTagName('INPUT')[0].id;
-				removeInputHandler(e);
-				break;
+	if (8 === keycode) {
+		if (wasEmpty) {
+			var i, siblings = [divObject.previousSibling, divObject.nextSibling];
+			for (i = 0; i < siblings.length; i++) {
+				if (undefined !== siblings[i] && "DIV" === siblings[i].tagName) {
+					nextFocusId = siblings[i].getElementsByTagName('INPUT')[0].id;
+					removeInputHandler(e);
+					break;
+				}
 			}
+		}
+		else if (! inputLength) {
+			wasEmptyObj.value = 'true';
+			return;
+		}
 	}
-	else if (0 !== inputLength && 13 === keycode) {
+	else if (13 === keycode && ! wasEmpty) {
 		var whichList = divObject.parentNode.id;
 		nextFocusId = 'option' + whichList + inputLast; 
 		addInput(whichList);
 	}
+	else {
+		wasEmptyObj.value = inputLength ? 'false' : 'true';
+		return;
+	}
 
-	if (undefined !== nextFocusId) document.getElementById(nextFocusId).focus();
+	if (nextFocusId) document.getElementById(nextFocusId).focus();
 }
 
 function addInput(whichList, itemValue) {
@@ -194,6 +201,10 @@ function addInput(whichList, itemValue) {
 		e.target.removeEventListener('keyup', inputKeyUpHandler);
 	});
 
+	optionWasEmpty = document.createElement('param');
+	optionWasEmpty.name = 'wasEmpty';
+	optionWasEmpty.value = itemValue.length ? 'false' : 'true';
+
 	optionAdd = document.createElement('a');
 	optionAdd.href = '#';
 	optionAdd.addEventListener('click', removeInputHandler, false);
@@ -211,6 +222,7 @@ function addInput(whichList, itemValue) {
 	optionDiv.id = 'option' + whichList + currentLength + '_div';
 	optionDiv.appendChild(optionAdd);
 	optionDiv.appendChild(optionInput);
+	optionDiv.appendChild(optionWasEmpty);
 	optionDiv.appendChild(optionLinebreak);
 
 	listDiv.insertBefore(optionDiv, listAdd);

--- a/src/data/script.js
+++ b/src/data/script.js
@@ -6,7 +6,7 @@
 // ==/UserScript==
 
 var defaultSettings = {
-	'version': '0.4.22',
+	'version': '0.4.23',
 	'listBlack': ['iphone', 'ipad'],
 	'listWhite': ['bjorn', 'octopus'],
 	'show_notice': true,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Tumblr Savior",
-	"version": "0.4.22",
+	"version": "0.4.23",
 	"description": "Tired of iPad posts filling up your dashboard? Hate hearing about an athlete's latest blunders? Tumblr Savior is here to save you!",
 	"background": {
 		"scripts": ["data/defaults.js", "lib/main.js"]

--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
 	"name": "tumblr-savior",
 	"license": "MPL 2.0",
 	"author": "Bjorn Stromberg",
-	"version": "0.4.22",
+	"version": "0.4.23",
 	"fullName": "Tumblr Savior",
 	"id": "jid1-W5guVoyeUR0uBg",
 	"description": "Tired of iPad posts filling up your dashboard? Hate hearing about an athlete's latest blunders? Tumblr Savior is here to save you!",


### PR DESCRIPTION
## Enter and backspace keys to add and remove black/white list items
- [x] Added lists UI feature:
  * When focused on non-empty input field, release enter to add new field and change focus to it
  * When focused on empty input field, release backspace to remove current field.  Does not remove an input field if it is the only one remaining in its list.  If available, changes focus to previous field, else change focus to next field.

- [x] Changed list remove button click-handler to named function (removeInputHandler), in order to be used with added feature.

- [x] [SOLVED]: There is one issue that I'm not quite sure how to resolve eloquently. The back button removes the field with the keystroke that removes the last remaining character. Of course, it is then as easy as pressing enter to create a new field and focus on it. However, it is not what I desired from the feature when I conceived it.