### PR TITLE
Stop browser from navigating to author's page when revealing a post

### DIFF
--- a/src/data/script.js
+++ b/src/data/script.js
@@ -372,6 +372,7 @@ function handleReveal(e) {
 
 	e.preventDefault();
 	e.stopPropagation();
+	e.stopImmediatePropagation();
 
 	searchUp = e.target;
 


### PR DESCRIPTION
My browser (chrome) began opening a new tab and loading the post author's page every time I clicked to reveal a post (even if I targeted the click to reveal link).

This fixes that issue but also stops all links on the minimised post from working. You have to expand the post before interacting with it.

I am happy to hide this fix behind a setting if preferred.

Thanks!