### PR TITLE
Shorten notice & use a palette variable for its background

### DIFF
--- a/src/data/script.js
+++ b/src/data/script.js
@@ -103,19 +103,24 @@ const showButtonStyle = [`
 
 const noticeStyle = [`
 	ts-notice ._2m1qj {
-		background-color: rgba(0,0,0,10%);
+		background-color: var(--gray-7);
 		display: flex;
 		white-space: normal;
 	}
 	ts-notice svg {
-		width: 64px;
+		max-height: 32px;
 	}
 	ts-notice div.content {
 		flex: 1 1 0;
 		padding-left: 10px;
 	}
 	ts-notice h1 {
-		margin-top: 5px;
+		display: inline; 
+		font-size: inherit; 
+		font-weight: bold;
+	}
+	ts-notice .content>h1::after { 
+		content: ': '; 
 	}
 	article.tumblr-savior-blacklisted.tumblr-savior-override ts-notice {
 		display: none;
@@ -406,7 +411,7 @@ function decoratePost(post, blackList, whiteList) {
 	divContent.className = 'content';
 
 	const h1Content = document.createElement('h1');
-	h1Content.appendChild(document.createTextNode('Content Warning'));
+	h1Content.appendChild(document.createTextNode('Content warning'));
 	divContent.appendChild(h1Content);
 
 	const spanContent = document.createElement('span');


### PR DESCRIPTION
This pull request:
- limits the height of the SVG warning symbol, though the implementation of this could be better
- uses a palette variable grey as the notice background, for increased compatibility with different palettes
- puts the "Content warning" heading on same line as the details, creating a more compact message
- switches the header from "Content Warning" to "Content warning", for stylistic reasons

Rationale for these changes: Making blocked posts have a more minimal presence on the dashboard improves user experience, at least for some. And the SVG symbol currently squishes even brief warnings onto multiple lines.

This pull request doesn't engage with flexbox as it should, but I've tested the CSS changes as a userstyle, and they are still an improvement over the status quo.

Here's how a warning currently looks, on dark mode:
![low-contrast-warning](https://user-images.githubusercontent.com/12678997/79026388-8272bb00-7b3d-11ea-90c6-07a3fd92c22a.png)

Here's about how that warning would look with these changes:
![darkmode-new-style](https://user-images.githubusercontent.com/12678997/79026548-13e22d00-7b3e-11ea-906b-f7ae3c416263.png)
