### PR TITLE
Update Script.js to catch reblog info in header

### DIFF
--- a/src/data/script.js
+++ b/src/data/script.js
@@ -456,11 +456,11 @@ function checkPost(post) {
 
 	let postText = '';
 
-	const postHeader = post.querySelector('header');
+	const postHeader = post.querySelector('header').ariaLabel;
 	const postTags = post.querySelector('.pOoZl');
 
 	if (!settings.ignore_header) {
-		postText += extractText(postHeader);
+		postText += postHeader;
 	}
 
 	if (!settings.ignore_body) {


### PR DESCRIPTION
Allows blacklist entries of the form "bjornstar reblogged a post from prokopetz" to block all reblogs of prokopetz by bjornstar. Similarly "bjornstar reblogged" will block all reblogs by bjornstar regardless of source.