### PR TITLE
v1.6.3 - 2020-12-27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.6.3 - 2020-12-27
  * Properly apply default settings when there weren't any saved settings
+ * Ignore `filteredScreen` content in the body, this avoids filtering out Tumblr's filter messages which do not have footers
 
 ## v1.6.2 - 2020-10-10
  * [`manifest.json`] Forgot to update the version

--- a/src/data/script.js
+++ b/src/data/script.js
@@ -24,6 +24,7 @@ const CSS_CLASS_MAP = {
 	contentSource: 'hjr__',
 	controlIcon: '_33VXm',
 	controls: '_1kqDq',
+	filteredScreen: 'LihFc',
 	footerWrapper: '_3TeiW',
 	footer: '_2dGhQ',
 	listTimelineObject: '_1DxdS',
@@ -42,7 +43,6 @@ const CSS_CLASS_MAP = {
 function css(className) {
 	return `.${CSS_CLASS_MAP[className]}`;
 }
-
 
 let settings = defaultSettings;
 let gotSettings = false;
@@ -484,7 +484,7 @@ function checkPost(post) {
 
 	if (!settings.ignore_body) {
 		const postBody = Array.prototype.reduce.call(post.childNodes, (out, { classList, innerHTML, tagName }) => {
-			if (['HEADER', 'TS-NOTICE'].includes(tagName) || classList.contains(CSS_CLASS_MAP.footerWrapper)) {
+			if (['HEADER', 'TS-NOTICE'].includes(tagName) || classList.contains(CSS_CLASS_MAP.footerWrapper) || classList.contains(CSS_CLASS_MAP.filteredScreen)) {
 				return out;
 			}
 			return out + innerHTML;


### PR DESCRIPTION
 * Ignore `filteredScreen` content in the body, this avoids filtering out Tumblr's filter messages which do not have footers