### PR TITLE
v1.16.0 / 2024-05-17

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,11 +19,10 @@ jobs:
         node-version: [20.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm i
-    - run: npm run build --if-present
     - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Tumblr Savior Changelog
 
+## v1.16.0 / 2024-05-17
+* Updated hiding sponsored posts, now just does `moatContainer`
+* Removed the hydration canary in favor of assuming hydration has succeeded the first time the base container is updated
+* Apply default values when individual options have not been set yet
+* Added a new option to block posts that are `timelineObject`s
+* Added a new option to block buttons in the sidebar (Go ad-free today)
+* Reorganized the options slightly to separate sidebar from posts
+* Updates `eslint` & `addons-linter` to latest version
+* Update more workflows to use node v20
+
 ## v1.15.0 / 2023-08-26
 * Update for the latest version of the desktop
 * New `CSS_CLASS_MAP` -- https://assets.tumblr.com/pop/cssmap-232fd5ad.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tumblr-savior",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Would you like to control what shows up on your dashboard? Tumblr Savior is here to save you!",
   "scripts": {
     "addons-linter": "addons-linter src",
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bjornstar/Tumblr-Savior#readme",
   "devDependencies": {
-    "addons-linter": "^6.12.0",
-    "eslint": "^8.48.0"
+    "addons-linter": "^6.24.0",
+    "eslint": "^8.57.0"
   }
 }

--- a/src/data/defaults.js
+++ b/src/data/defaults.js
@@ -6,9 +6,11 @@ const defaultSettings = {
 	'hide_reblog_header': true,
 	'hide_recommended_blogs': true,
 	'hide_recommended_posts': true,
+	'hide_sidebar_buttons': true,
 	'hide_source': true,
 	'hide_sponsored': true,
 	'hide_sponsored_sidebar': true,
+	'hide_timeline_objects': true,
 	'ignore_body': false,
 	'ignore_filtered_content': true,
 	'ignore_header': false,
@@ -20,5 +22,5 @@ const defaultSettings = {
 	'show_notice': true,
 	'show_tags': true,
 	'show_words': true,
-	'version': '1.15.0'
+	'version': '1.16.0'
 }; // Initialize default values.

--- a/src/data/options.html
+++ b/src/data/options.html
@@ -58,7 +58,7 @@
             <label for="ignore_tags_cb" class="ignore_label">Ignore tags</label>
           </div>
           <br />
-          <h2>Tumblr Behavior</h2>
+          <h2>Tumblr Posts</h2>
           <div id="hide_source_div">
             <input type="checkbox" id="hide_source_cb" name="hide_source_cb" /> <label for="hide_source_cb">Hide source attribution</label>
           </div>
@@ -68,23 +68,30 @@
           <div id="hide_filtered_content_div">
             <input type="checkbox" id="hide_filtered_content_cb" name="hide_filtered_content_cb" /> <label for="hide_filtered_content_cb">Hide filtered content</label>
           </div>
-          <div id="hide_radar_div">
-            <input type="checkbox" id="hide_radar_cb" name="hide_radar_cb" /> <label for="hide_radar_cb">Hide the radar in the sidebar</label>
-          </div>
-          <div id="hide_recommended_blogs_div">
-            <input type="checkbox" id="hide_recommended_blogs_cb" name="hide_recommended_blogs_cb" /> <label for="hide_recommended_blogs_cb">Hide recommended blogs in the sidebar</label>
-          </div>
           <div id="hide_recommended_posts_div">
             <input type="checkbox" id="hide_recommended_posts_cb" name="hide_recommended_posts_cb" /> <label for="hide_recommended_posts_cb">Hide recommended posts</label>
           </div>
           <div id="hide_sponsored_div">
             <input type="checkbox" id="hide_sponsored_cb" name="hide_sponsored_cb" /> <label for="hide_sponsored_cb">Hide sponsored posts</label>
           </div>
-          <div id="hide_yahoo_ads_div">
-            <input type="checkbox" id="hide_sponsored_sidebar_cb" name="hide_sponsored_sidebar_cb" /> <label for="hide_sponsored_sidebar_cb">Hide the sponsored section in the sidebar</label>
+          <div id="hide_timeline_objects_div">
+            <input type="checkbox" id="hide_timeline_objects_cb" name="hide_timeline_objects_cb" /> <label for="hide_timeline_objects_cb">Hide timeline objects</label>
           </div>
-          <div id="remove_redirects">
+          <div id="remove_redirects_div">
             <input type="checkbox" id="remove_redirects_cb" name="remove_redirects_cb" /> <label for="remove_redirects_cb">Remove href.li redirects</label>
+          </div>
+          <h2>Sidebar</h2>
+          <div id="hide_radar_div">
+            <input type="checkbox" id="hide_radar_cb" name="hide_radar_cb" /> <label for="hide_radar_cb">Hide the radar</label>
+          </div>
+          <div id="hide_recommended_blogs_div">
+            <input type="checkbox" id="hide_recommended_blogs_cb" name="hide_recommended_blogs_cb" /> <label for="hide_recommended_blogs_cb">Hide recommended blogs</label>
+          </div>
+          <div id="hide_sidebar_buttons_div">
+            <input type="checkbox" id="hide_sidebar_buttons_cb" name="hide_sidebar_buttons_cb" /> <label for="hide_sidebar_buttons_cb">Hide buttons</label>
+          </div>
+          <div id="hide_sponsored_sidebar_div">
+            <input type="checkbox" id="hide_sponsored_sidebar_cb" name="hide_sponsored_sidebar_cb" /> <label for="hide_sponsored_sidebar_cb">Hide the sponsored section</label>
           </div>
         </div>
         <div id="saveloadDiv">

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -10,9 +10,11 @@ const settingsInputs = { //match up our settings object with our dom.
 		hide_reblog_header: 'hide_reblog_header_cb',
 		hide_recommended_blogs: 'hide_recommended_blogs_cb',
 		hide_recommended_posts: 'hide_recommended_posts_cb',
+		hide_sidebar_buttons: 'hide_sidebar_buttons_cb',
 		hide_source: 'hide_source_cb',
 		hide_sponsored: 'hide_sponsored_cb',
 		hide_sponsored_sidebar: 'hide_sponsored_sidebar_cb',
+		hide_timeline_objects: 'hide_timeline_objects_cb',
 		ignore_body: 'ignore_body_cb',
 		ignore_filtered_content: 'ignore_filtered_content_cb',
 		ignore_header: 'ignore_header_cb',
@@ -96,7 +98,7 @@ function parseSettings() {
 		}
 	}
 
-	return parsedSettings;
+	return { ...defaultSettings, ...parsedSettings };
 }
 
 function removeElement(id) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Tumblr Savior",
-	"version": "1.15.0",
+	"version": "1.16.0",
 	"description": "Would you like to control what shows up on your dashboard? Tumblr Savior is here to save you!",
 	"background": {
 		"scripts": [ "data/defaults.js", "lib/main.js" ]


### PR DESCRIPTION
* Updated hiding sponsored posts, now just does `moatContainer`
* Removed the hydration canary in favor of assuming hydration has succeeded the first time the base container is updated
* Apply default values when individual options have not been set yet
* Added a new option to block posts that are `timelineObject`s
* Added a new option to block buttons in the sidebar (Go ad-free today)
* Reorganized the options slightly to separate sidebar from posts
* Updates `eslint` & `addons-linter` to latest version